### PR TITLE
Added Static response capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 npm-debug.log
+node_modules

--- a/resources/dbcreate.sql
+++ b/resources/dbcreate.sql
@@ -102,6 +102,13 @@ MINVALUE 1
 MAXVALUE 9223372036854775807
 CACHE 1;
 
+CREATE SEQUENCE public.response_type_response_type_id_seq
+INCREMENT 1
+START 1
+MINVALUE 1
+MAXVALUE 9223372036854775807
+CACHE 1;
+
 CREATE SEQUENCE public.synonym_variant_synonym_id_seq
 INCREMENT 1
 START 1
@@ -174,11 +181,22 @@ WITH (
 )
 TABLESPACE pg_default;
 
+CREATE TABLE public.response_type
+(
+  response_type_id integer NOT NULL DEFAULT nextval('response_type_response_type_id_seq'::regclass),
+  response_type_text character varying COLLATE pg_catalog."default",
+  CONSTRAINT response_type_id_pk PRIMARY KEY (response_type_id)
+)
+WITH (
+  OIDS = FALSE
+)
+TABLESPACE pg_default;
+
 CREATE TABLE public.responses
 (
   intent_id integer NOT NULL,
   response_text character varying COLLATE pg_catalog."default",
-  response_type integer,
+  response_type integer REFERENCES response_type (response_type_id),
   response_id integer NOT NULL DEFAULT nextval('responses_response_id_seq'::regclass)
 )
 WITH (
@@ -304,3 +322,6 @@ FROM nlu_log
 GROUP BY (to_char(nlu_log."timestamp", 'MM/DD'::text))
 ORDER BY (to_char(nlu_log."timestamp", 'MM/DD'::text))
 LIMIT 30;
+
+/* Static Data */
+INSERT INTO response_type (response_type_text) VALUES ('DEFAULT'),('RICH TEXT');

--- a/server/db/responses.js
+++ b/server/db/responses.js
@@ -1,0 +1,74 @@
+const db = require('./db')
+
+function getIntentResponses(req, res, next) {
+  console.log("responses.getIntentResponses");
+  var intentID = parseInt(req.params.intent_id);
+  console.log("responses.getIntentResponses ::intentID" +intentID);
+  db.any('select * from responses where intent_id = $1', intentID)
+    .then(function (data) {
+      res.status(200).json(data);
+    })
+    .catch(function (err) {
+      return next(err);
+    });
+}
+
+function createIntentResponse(req, res, next) {
+  console.log("responses.createIntentResponse");
+  //using default response type
+  db.any('insert into responses(intent_id, response_text, response_type)' +
+      'values(${intent_id}, ${response_text},${response_type})',
+      //using default response type
+    req.body)
+    .then(function () {
+      res.status(200)
+        .json({
+          status: 'success',
+          message: 'Inserted'
+        });
+    })
+    .catch(function (err) {
+      return next(err);
+    });
+}
+
+function removeIntentResponse(req, res, next) {
+  var responseID = parseInt(req.params.response_id);
+  console.log("responses.removeIntentResponse");
+  db.result('delete from responses where response_id = $1', responseID)
+    .then(function (result) {
+
+      res.status(200)
+        .json({
+          status: 'success',
+          message: 'Removed ' +result.rowCount
+        });
+      /* jshint ignore:end */
+    })
+    .catch(function (err) {
+      return next(err);
+    });
+}
+
+function getRandomResponseForIntent(req, res, next) {
+  console.log("responses.getRandomResponseForIntent");
+  db.result('SELECT * FROM responses, intents where responses.intent_id= intents.intent_id and intents.intent_name=$1', req.query.intent_name)
+    .then(function (data) {
+      //pick random one if there are multiple.
+      if(data.length>1){
+        //pick one
+        res.status(200).json(data[Math.random() * (data.length - 1) + 1]);
+      }
+      res.status(200).json(data);
+    })
+    .catch(function (err) {
+      return next(err);
+    });
+}
+
+module.exports = {
+  getIntentResponses: getIntentResponses,
+  removeIntentResponse: removeIntentResponse,
+  createIntentResponse: createIntentResponse,
+  getRandomResponseForIntent:getRandomResponseForIntent
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,6 +9,7 @@ var entities = require('../db/entities');
 var synonyms = require('../db/synonyms');
 var variants = require('../db/variants');
 var settings = require('../db/settings');
+var responses = require('../db/responses');
 var logs = require('../db/logs');
 
 router.get('/agents', agents.getAllAgents);
@@ -63,6 +64,13 @@ router.delete('/synonyms/:synonym_id/variants', variants.removeSynonymVariants);
 router.get('/settings', settings.getSettings);
 router.get('/settings/:setting_name', settings.getSingleSetting);
 router.put('/settings/:setting_name', settings.updateSetting);
+
+
+router.get('/response/:intent_id', responses.getIntentResponses);
+router.get('/rndmresponse', responses.getRandomResponseForIntent);
+router.post('/response', responses.createIntentResponse);
+router.delete('/response/:response_id', responses.removeIntentResponse);
+
 
 router.get('/nlu_log/:query', logs.getLogs);
 router.get('/intent_usage_by_day', logs.getIntentUsageByDay);

--- a/web/src/app/components/intents/edit_intent.html
+++ b/web/src/app/components/intents/edit_intent.html
@@ -89,5 +89,41 @@
         </div>
       </div>
     </div>
+
+    <div class="row">
+      <div class="col-sm-12 col-lg-12">
+        <form>
+          <div class="card">
+            <div class="card-header">
+              <strong>Intent Reponses</strong>
+            </div>
+            <!-- Nav tabs -->
+            <ul class="nav nav-tabs" role="tablist" style="padding-left: 5px; padding-top: 5px;">
+              <li class="nav-item">
+                <a class="nav-link active" data-toggle="tab" href="#DEFAULT" role="tab">DEFAULT</a>
+              </li>
+            </ul>
+            <!-- Tab panes -->
+            <div class="tab-content">
+                <div class="tab-pane active" id="DEFAULT" role="tabpanel">
+                  <input type="text" ng-model="formData.response_text" class="form-control" id="text" placeholder="Enter a Response Text" ng-keyup="$event.keyCode == 13 && saveNewResponse($event)" placeholder="Enter a text response" ><br>
+                  <ul class="list-group" style="max-height: 300px; overflow-y:scroll;">
+                    <li class="list-group-item" ng-repeat="response in responses track by response.response_id">
+                      <span ng-bind-html="response.response_text | trusted"></span>
+                      <span class="pull-right">
+                        <button class="btn btn btn-outline-danger" confirm-click-title="Delete Response" confirm-click="Are you sure? This will delete the response." ng-click="deleteResponse(response.response_id)">
+                          <span class="icon-trash"></span>
+                        </button>
+                      </span>
+                    </li>
+                  </ul>
+                </div>
+            </div>
+            <div class="card-footer">
+            </div>
+          </form>
+          </div>
+        </div>
+      </div>
   </div>
 </div>

--- a/web/src/app/components/intents/edit_intent.js
+++ b/web/src/app/components/intents/edit_intent.js
@@ -2,7 +2,7 @@ angular
 .module('app')
 .controller('EditIntentController', EditIntentController)
 
-function EditIntentController($rootScope, $scope, Agent, Intent, Expressions, Expression, Parameter, Parameters, Entities, UniqueIntentEntities) {
+function EditIntentController($rootScope, $scope, Agent, Intent, Expressions, Expression, Parameter, Parameters, Entities, UniqueIntentEntities,Responses, Response ) {
   Agent.get({agent_id: $scope.$routeParams.agent_id}, function(data) {
       $scope.agent = data;
   });
@@ -10,12 +10,12 @@ function EditIntentController($rootScope, $scope, Agent, Intent, Expressions, Ex
   Entities.query( function(data) {
       $scope.entityList = data;
   });
-
   Intent.get({intent_id: $scope.$routeParams.intent_id}, function(data) {
       $scope.intent = data;
   });
 
   loadExpressions();
+  loadResponses();
   loadUniqueIntentEntities();
 
   function loadExpressions() {
@@ -23,6 +23,26 @@ function EditIntentController($rootScope, $scope, Agent, Intent, Expressions, Ex
         $scope.expressionList = data;
         loadParameters();
       });
+  }
+  function loadResponses(){
+    Responses.query({intent_id: $scope.$routeParams.intent_id}, function(data) {
+        $scope.responses = data;
+    });
+  }
+  $scope.saveNewResponse = function(event){
+    this.formData.intent_id = $scope.$routeParams.intent_id;
+    this.formData.response_type = 1;//DEFAULT type
+    Response.save(this.formData).$promise.then(function(resp) {
+      //update list
+      loadResponses();
+      //empty formData
+      $scope.formData={}
+    });
+  }
+  $scope.deleteResponse = function(response_id) {
+    Response.remove({response_id: response_id}).$promise.then(function(resp) {
+      loadResponses();
+    });
   }
 
   $scope.runExpression = function(expression_text) {

--- a/web/src/app/services/api.js
+++ b/web/src/app/services/api.js
@@ -70,3 +70,14 @@ return $resource(api_endpoint_v2 + '/settings/:setting_name', {setting_id:'@id'}
         'update': { method:'PATCH' }
     });
 }]);
+//All responses for an intent
+app.factory('Responses', function($resource) {
+  return $resource(api_endpoint_v2 + '/response/:intent_id', {intent_id:'@id'});
+});
+//Reponse actions: create and delete
+app.factory('Response', function($resource) {
+  return $resource(api_endpoint_v2 + '/response/:response_id', {response_id:'@id'});
+});
+app.factory('IntentResponse', function($resource) {
+  return $resource(api_endpoint_v2 + '/rndmresponse');
+});

--- a/web/src/app/shared/aside/aside.html
+++ b/web/src/app/shared/aside/aside.html
@@ -23,6 +23,11 @@
           <small><b>Output</b>
           </small>
         </div>
+        <div class="callout m-0 py-3">{{response_text}}</div>
+        <div class="callout m-0 py-2 text-muted text-center bg-faded text-uppercase">
+          <small><b>JSON Data</b>
+          </small>
+        </div>
         <div class="callout m-0 py-3">
           <json-formatter json="test_text_response" open="3"></json-formatter>
         </div>

--- a/web/src/app/shared/aside/aside.js
+++ b/web/src/app/shared/aside/aside.js
@@ -2,9 +2,10 @@ angular
 .module('app')
 .controller('AsideController', AsideController)
 
-function AsideController($scope, $rootScope, $interval, Rasa_Parse, Rasa_Config, Rasa_Version, Settings, Rasa_Status) {
+function AsideController($scope, $rootScope, $interval, Rasa_Parse, Rasa_Config, Rasa_Version, Settings, Rasa_Status, IntentResponse) {
   $scope.test_text = 'I want italian food in new york';
   $scope.test_text_response = {};
+  $scope.response_text ="Your configured reponses Appear here"
   $rootScope.config = {}; //Initilize in case server is not online at startup
   var configcheck;
 
@@ -54,9 +55,8 @@ function AsideController($scope, $rootScope, $interval, Rasa_Parse, Rasa_Config,
     });
   }
 
-
-
   $scope.executeTestRequest = function() {
+    $scope.response_text=''
     var options = {};
     var model = '';
     if ($scope.modelname !== 'Default') {
@@ -64,7 +64,13 @@ function AsideController($scope, $rootScope, $interval, Rasa_Parse, Rasa_Config,
     }
     options = {query: $scope.test_text, model: model};
     Rasa_Parse.get(options, function(data) {
-        $scope.test_text_response = data.toJSON();
+      $scope.test_text_response = data.toJSON();
+      //if there is a default response to this intent, pick a random one and show it.
+      var intent_name = data.intent.name;
+      IntentResponse.get({intent_name: intent_name}, function(data){
+        if(data.rowCount> 0)
+          $scope.response_text = data.rows[0].response_text;
+      });
     });
   }
 }

--- a/web/src/assets/css/style.css
+++ b/web/src/assets/css/style.css
@@ -51,3 +51,5 @@
 tags-input .tags .tag-item .remove-button {
     color: #fff;
 }
+.list-group-item:hover, a.list-group-item:focus {text-decoration: none;background-color: rgb(245, 245, 245);}
+.list-group { margin-bottom:0px; }


### PR DESCRIPTION
Ability to configure static responses in Postgres and see the responses right on the console.

---------
DB Setup
-----------
Updated dbcreate.sql

added response_type TABLE
added response_type Sequences
updated response table to have reference to response_type

Added static data to response_type

-----
Server Setup
------------
added server/db/reponses.js  
added routes for responses and response_type in server/routes/index.js

-------
UI Setup
-------
Added listgroup hover style i style.css
added API for Response text (DEFAULT TYPE for now)
edit intent page is modified to include Response.
Aside Page is modified to include the static response.

Next steps: Webhook integration enablement and passthrough of all the requests via middleware and log the responses as well.
