### PR TITLE
fetchActionDetailsFromDb: Correct reject message when no actions found in DB

### DIFF
--- a/server/routes/mw_routes/core_router.js
+++ b/server/routes/mw_routes/core_router.js
@@ -299,9 +299,8 @@ var await = require('asyncawait/await');
         .then(function (data) {
           if (data.length > 0) {
             resolve(data[0]);
-          }else{
-            console.log("Error occurred. Respond back with Rasa NLU only");
-            reject(err); return;
+          } else {
+            reject("Didn't find action for action_name=" + action_name); return;
           }
         })
         .catch(function (err) {


### PR DESCRIPTION
There is no [`err` object provided](https://github.com/paschmann/rasa-ui/blob/d19fb8fad5df47154ba378f7e132f4169b264e06/server/routes/mw_routes/core_router.js#L304) when zero results returns from the DB query.