### PR TITLE
Bugfix/train wrong content type

### DIFF
--- a/server/routes/mw_routes/nlu_router.js
+++ b/server/routes/mw_routes/nlu_router.js
@@ -51,7 +51,7 @@ function trainRasaNlu(req, res, next) {
   request({
     method: "POST",
     uri: global.rasanluendpoint + "/train?project=" + req.query.project,
-    json: req.body
+    body: JSON.stringify(req.body)
   }, function (error, response, body) {
     if(error){
       console.log("Error Occured when posting data to nlu endpoint. " + error);

--- a/server/routes/mw_routes/nlu_router.js
+++ b/server/routes/mw_routes/nlu_router.js
@@ -51,7 +51,7 @@ function trainRasaNlu(req, res, next) {
   request({
     method: "POST",
     uri: global.rasanluendpoint + "/train?project=" + req.query.project,
-    body: JSON.stringify(req.body)
+    json: req.body
   }, function (error, response, body) {
     if(error){
       console.log("Error Occured when posting data to nlu endpoint. " + error);


### PR DESCRIPTION
Currently it's not possible to start agent training from the ui, because in the request to the rasa nlu /train endpoint, the wrong content type header is set. This fix will set the header to json.