### PR TITLE
Fix: Handle empty entities for uploads properly

### DIFF
--- a/server/db/agents.js
+++ b/server/db/agents.js
@@ -22,7 +22,7 @@ function uploadAgentFromFile(req, res, next) {
     var expressionObj = new Object();
     expressionObj.text = nlu_data_arr[i].text;
     expressionObj.paramArray = [];
-    var intentEntities = nlu_data_arr[i].entities;
+    var intentEntities = nlu_data_arr[i].entities || [];
     var entities_query_arr = [];
     for (j = 0; j < intentEntities.length; j++) {
       var entityObj = intentEntities[j];


### PR DESCRIPTION
close #129 

Quite simple to fix to stop the upload from failing silently. Entities are not always set and should default to an empty array.