### PR TITLE
Set rasa_endpoint to localhost:5005 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "winston": "^3.2.1"
   },
   "config": {
-    "rasa_endpoint": "http://10.211.55.8:5005",
+    "rasa_endpoint": "http://localhost:5005",
     "loglevel": "info",
     "jwtsecret": "mysecret",
     "admin_username": "admin",


### PR DESCRIPTION
Fixes #246 by setting "rasa_endpoint" to "http://localhost:5005" by default in package.json